### PR TITLE
사용자 프로필 사진 수정, 자기소개 수정기능을 추가하였습니다.

### DIFF
--- a/AniHouse-iOS/AniHouse-iOS.xcodeproj/project.pbxproj
+++ b/AniHouse-iOS/AniHouse-iOS.xcodeproj/project.pbxproj
@@ -47,6 +47,7 @@
 		BBD6FB0C281A983300BCA90F /* MainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBD6FB0B281A983300BCA90F /* MainView.swift */; };
 		BBD6FB0E281AC23C00BCA90F /* AddPostView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBD6FB0D281AC23C00BCA90F /* AddPostView.swift */; };
 		BBD6FB2A281AF5EE00BCA90F /* PhotoPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBD6FB29281AF5EE00BCA90F /* PhotoPicker.swift */; };
+		BBD8666B283EA38600B9A9DF /* EditProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBD8666A283EA38600B9A9DF /* EditProfileView.swift */; };
 		BBDA79DA28300C5000EF5DA2 /* PrivacyStatementView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBDA79D928300C5000EF5DA2 /* PrivacyStatementView.swift */; };
 		BBDDF9A02822CF1900B3001A /* MainPostViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBDDF99F2822CF1900B3001A /* MainPostViewModel.swift */; };
 		BBDDF9A22822CF6600B3001A /* MainPost.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBDDF9A12822CF6600B3001A /* MainPost.swift */; };
@@ -98,6 +99,7 @@
 		BBD6FB0B281A983300BCA90F /* MainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainView.swift; sourceTree = "<group>"; };
 		BBD6FB0D281AC23C00BCA90F /* AddPostView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddPostView.swift; sourceTree = "<group>"; };
 		BBD6FB29281AF5EE00BCA90F /* PhotoPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoPicker.swift; sourceTree = "<group>"; };
+		BBD8666A283EA38600B9A9DF /* EditProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditProfileView.swift; sourceTree = "<group>"; };
 		BBDA79D928300C5000EF5DA2 /* PrivacyStatementView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyStatementView.swift; sourceTree = "<group>"; };
 		BBDDF99F2822CF1900B3001A /* MainPostViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainPostViewModel.swift; sourceTree = "<group>"; };
 		BBDDF9A12822CF6600B3001A /* MainPost.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainPost.swift; sourceTree = "<group>"; };
@@ -290,6 +292,7 @@
 			isa = PBXGroup;
 			children = (
 				BBDA79D928300C5000EF5DA2 /* PrivacyStatementView.swift */,
+				BBD8666A283EA38600B9A9DF /* EditProfileView.swift */,
 				BB120F3B283E075900F361A1 /* ShowPostDidWrite */,
 			);
 			path = SettingSubViews;
@@ -464,6 +467,7 @@
 				91D6BD60282D1E0A00A6168C /* FreeAddCommentView.swift in Sources */,
 				BBD6FB0E281AC23C00BCA90F /* AddPostView.swift in Sources */,
 				BB120F3D283E0A5D00F361A1 /* ShowPostCell.swift in Sources */,
+				BBD8666B283EA38600B9A9DF /* EditProfileView.swift in Sources */,
 				BBD6FB2A281AF5EE00BCA90F /* PhotoPicker.swift in Sources */,
 				BB120F3A283E068200F361A1 /* ShowPostDidWrite.swift in Sources */,
 				917BC4C0282E566B00C9D0EE /* FreeCommentView.swift in Sources */,

--- a/AniHouse-iOS/AniHouse-iOS/ViewModels/StorageManager.swift
+++ b/AniHouse-iOS/AniHouse-iOS/ViewModels/StorageManager.swift
@@ -13,6 +13,8 @@ class StorageManager: ObservableObject {
     let storage = Storage.storage()
     var imageURL = URL(string: "")
     @Published var mainPostImages = [String: UIImage]()
+    @Published var profileImage: UIImage = UIImage(named: Constant.ImageName.defaultUserImage)!
+    @Published var introduce: String = "자기소개 입니다."
     
     
     // 이미지를 업로드
@@ -32,4 +34,56 @@ class StorageManager: ObservableObject {
             }
         }
     }
+    
+    func getUserProfileImage(email: String) {
+        print("StorageManager - getUserProfileImage")
+        let storage = Storage.storage().reference()
+        storage.child("user/profileImage/\(email)").downloadURL{ url, err in
+//            print("url: \(url!)")
+            guard err == nil else { return }
+            self.downloadImage(url: url!)
+        }
+    }
+    
+    func getData(from url: URL, completion: @escaping (Data?, URLResponse?, Error?) -> ()) {
+        URLSession.shared.dataTask(with: url, completionHandler: completion).resume()
+    }
+    func downloadImage(url: URL) {
+        print("Download Started")
+        getData(from: url) { data, response, error in
+            guard let data = data, error == nil else { return }
+            print(response?.suggestedFilename ?? url.lastPathComponent)
+            print("Download Finished")
+            DispatchQueue.main.async() { [weak self] in
+                self?.profileImage = UIImage(data: data)!
+            }
+        }
+    }
+//    func loadMainImage(imageName: String) {
+//        let storage = Storage.storage().reference()
+//        storage.child("MainPostImage/\(imageName).jpg").downloadURL { url, err in
+//            if err != nil {
+//                print((err?.localizedDescription)!)
+//                return
+//            }
+//            self.url = "\(url!)"
+//        }
+//    }
+    func uploadUserProfileImage(email: String) {
+        print("StorageManager - uploadUserProfileImage()")
+        let storageRef = storage.reference().child("user/profileImage/\(email)")
+        let data = self.profileImage.jpegData(compressionQuality: 0.5)
+        
+        let metadata = StorageMetadata()
+        metadata.contentType = "image/jpg"
+        
+        if let data = data {
+            storageRef.putData(data, metadata: metadata) { (metadata, error) in
+                guard error == nil else { return }
+                guard let metadata = metadata else { return }
+//                print("metadata: \(metadata)")
+            }
+        }
+    }
+    
 }

--- a/AniHouse-iOS/AniHouse-iOS/ViewModels/UserInfoViewModel.swift
+++ b/AniHouse-iOS/AniHouse-iOS/ViewModels/UserInfoViewModel.swift
@@ -15,6 +15,7 @@ class UserInfoViewModel: ObservableObject {
     
     @Published var user = Auth.auth().currentUser
     @Published var userNickName: String = "userNickname"
+    @Published var userIntroduce: String = "default user introduce"
     @Published var userInfo: [UserInfo] = [UserInfo]()
     
     func addUser(name: String, nickName: String, email: String, birth: Date) {
@@ -28,7 +29,7 @@ class UserInfoViewModel: ObservableObject {
         }
     }
     
-    func getUserNickName(email: String) {
+    func getUserInfo(email: String) {
         if user == nil {
             print("유저가 없어요")
         }
@@ -39,11 +40,20 @@ class UserInfoViewModel: ObservableObject {
         db.collection("userInfo").document(email).getDocument { document, error in
             if let document = document {
                 self.userNickName = document.get("nickName") as! String
-                print("getnickName: \(self.userNickName)")
-                print("닉네임을 찾았어요!")
+                self.userIntroduce = document.get("introduce") as? String ?? ""
+                print("getnickName: \(self.userNickName), introduce: \(self.userIntroduce)")
+                print("자기소개와 닉네임을 찾았어요!")
             } else {
-                print("닉네임을 가져오는데 실패했어요")
+                print("자기소개와 닉네임을 가져오는데 실패했어요")
             }
+        }
+    }
+    
+    func setUserIntroduce(email: String, introduce: String) {
+        let db = Firestore.firestore()
+        let ref = db.collection("userInfo").document(email)
+        ref.setData(["introduce": introduce], merge: true) {error in
+            guard error == nil else { return }
         }
     }
     

--- a/AniHouse-iOS/AniHouse-iOS/Views/FreeBoard/FreeBoardView.swift
+++ b/AniHouse-iOS/AniHouse-iOS/Views/FreeBoard/FreeBoardView.swift
@@ -168,7 +168,7 @@ struct FreeBoardView: View {
                     if let user = user {
                         print("유저의 정보를 찾았습니다.")
                         print(user.email)
-                        self.userInfoManager.getUserNickName(email: user.email!)
+                        self.userInfoManager.getUserInfo(email: user.email!)
                     } else {
                         print("기다리고 있어요...")
                     }

--- a/AniHouse-iOS/AniHouse-iOS/Views/LoginAndRegister/LoginView.swift
+++ b/AniHouse-iOS/AniHouse-iOS/Views/LoginAndRegister/LoginView.swift
@@ -25,7 +25,7 @@ struct LoginView: View {
         
         //        NavigationView {
         if UserDefaults.standard.bool(forKey: "loginCheck") {
-            let _ = print("viewModel.signedIn: \(viewModel.signedIn)")
+//            let _ = print("viewModel.signedIn: \(viewModel.signedIn)")
             // 로그인 성공하면 바로 TabBarView로 이동
             TabBarView()
 //                .environmentObject(viewModel)

--- a/AniHouse-iOS/AniHouse-iOS/Views/MainView/MainView.swift
+++ b/AniHouse-iOS/AniHouse-iOS/Views/MainView/MainView.swift
@@ -85,12 +85,13 @@ struct MainView: View {
                         print("유저의 정보를 찾았습니다.")
                         print(user.email)
                         self.userInfoManager.user = user
-                        self.userInfoManager.getUserNickName(email: user.email!)
+                        self.userInfoManager.getUserInfo(email: user.email!)
                     } else {
                         print("기다리고 있어요...")
                     }
                 }
                 mainFirestoreViewModel.getData()
+                storageManager.getUserProfileImage(email: userInfoManager.user!.email!)
             }
             .background(
                 Color(Constant.CustomColor.lightBrown)

--- a/AniHouse-iOS/AniHouse-iOS/Views/SettingView/SettingSubViews/EditProfileView.swift
+++ b/AniHouse-iOS/AniHouse-iOS/Views/SettingView/SettingSubViews/EditProfileView.swift
@@ -1,0 +1,99 @@
+//
+//  EditProfileView.swift
+//  AniHouse-iOS
+//
+//  Created by Jaehoon So on 2022/05/26.
+//
+
+import SwiftUI
+
+struct EditProfileView: View {
+    
+    @EnvironmentObject var viewModel: AppViewModel
+    @EnvironmentObject var userInfoManager: UserInfoViewModel
+    @EnvironmentObject var storageManager: StorageManager
+    
+    @State private var profileImage: UIImage = UIImage(named: Constant.ImageName.defaultUserImage)!
+    @State private var isShowingPhotoPicker: Bool = false
+    @State private var showUpdateProfileAlert: Bool = false
+    
+    var body: some View {
+        ZStack {
+            Color(Constant.CustomColor.normalBrown)
+                .ignoresSafeArea()
+            ScrollView {
+                VStack {
+                    ZStack(alignment: .bottomTrailing) {
+                        Image(uiImage: storageManager.profileImage)
+                            .resizable()
+                            .scaledToFit()
+                            .clipShape(Circle())
+                            .frame(width: 230, height: 230)
+                        Circle()
+                            .foregroundColor(.blue)
+                            .frame(width: 60, height: 60)
+                            .overlay {
+                                Image(systemName: "camera.viewfinder")
+                                    .font(.system(size: 25))
+                                    .foregroundColor(.white)
+                            }
+                            .onTapGesture {
+                                self.isShowingPhotoPicker.toggle()
+                            }
+                    }
+                    Text("\(self.userInfoManager.userNickName)")
+                        .fontWeight(.black)
+                        .font(.system(size: 30))
+                        .padding(5)
+                    
+                    ZStack {
+                        if storageManager.introduce.isEmpty {
+                            Text("자기소개를 입력해주세요")
+                                .foregroundColor(.secondary)
+                        }
+                        
+                        TextEditor(text: $storageManager.introduce)
+                            .background(Color(Constant.CustomColor.lightBrown))
+                            .cornerRadius(5)
+                            .frame(minWidth: nil, idealWidth: .infinity, maxWidth: nil,
+                                   minHeight: 200, idealHeight: 350, maxHeight: 300)
+                    }
+                    
+                    Button {
+                        self.showUpdateProfileAlert.toggle()
+                    } label: {
+                        Text("저장하기")
+                            .foregroundColor(.white)
+                            .fontWeight(.bold)
+                            .padding()
+                            .background(Color(Constant.CustomColor.strongBrown))
+                            .cornerRadius(10)
+                    }
+                    .alert(isPresented: self.$showUpdateProfileAlert) {
+                        Alert(title: Text("프로필 정보 변경"), message: Text("프로필 정보를 저장하시겠습니까?"),
+                              primaryButton: .default(Text("예"), action: {
+                            // 여기서 스토리지에 이미지를, 스토어에 자기소개 정보를 저장한다.
+                            print("프로필 정보를 저장합니다.")
+                            storageManager.uploadUserProfileImage(email: userInfoManager.user!.email!) // 프로필 이미지 저장
+                            userInfoManager.setUserIntroduce(email: userInfoManager.user!.email!, introduce: self.storageManager.introduce)
+                        }),
+                              secondaryButton: .destructive(Text("아니오")))
+                    }
+
+                    
+                }
+            }
+            .padding(.horizontal, 5)
+            .sheet(isPresented: $isShowingPhotoPicker, content: {
+                //content
+                PhotoPicker(bindedImage: $storageManager.profileImage)
+            })
+        }
+    }
+}
+
+struct EditProfileView_Previews: PreviewProvider {
+    static var previews: some View {
+        EditProfileView()
+    }
+}

--- a/AniHouse-iOS/AniHouse-iOS/Views/SettingView/SettingSubViews/ShowPostDidWrite/ShowPostDidWrite.swift
+++ b/AniHouse-iOS/AniHouse-iOS/Views/SettingView/SettingSubViews/ShowPostDidWrite/ShowPostDidWrite.swift
@@ -51,8 +51,8 @@ struct ShowPostDidWrite: View {
                     }
                 }
             }
+            .listStyle(InsetGroupedListStyle())
         }
-        .listStyle(GroupedListStyle())
 //        .background(Color(Constant.CustomColor.normalBrown))
         .navigationTitle("✍️ 내가 쓴 게시글")
         .navigationBarTitleDisplayMode(.inline)
@@ -69,11 +69,8 @@ struct ShowPostDidWrite: View {
         }
         .onAppear {
             print("email: \(userInfoViewModel.user!.email!)")
-            mainPostViewModel.getCurrentUserMainPost(email: userInfoViewModel.user!.email!)
-            freeBoardViewModel.getCurrentUserFreePost(email: userInfoViewModel.user!.email!)
-            DispatchQueue.main.asyncAfter(deadline: .now() + 1, execute: {
-                print("유저가 작성한 게시글 목록 \n\(mainPostViewModel.userMainPost)")
-            })
+            mainPostViewModel.getCurrentUserMainPost(email: userInfoViewModel.user!.email!) // 유저가 메인 게시판에 쓴 글을 불러온다.
+            freeBoardViewModel.getCurrentUserFreePost(email: userInfoViewModel.user!.email!) // 유저가 자유 게시판에 쓴 글을 불러온다.
         }
     }
 }

--- a/AniHouse-iOS/AniHouse-iOS/Views/SettingView/SettingView.swift
+++ b/AniHouse-iOS/AniHouse-iOS/Views/SettingView/SettingView.swift
@@ -11,6 +11,7 @@ import FirebaseAuth
 struct SettingView: View {
     @EnvironmentObject var viewModel: AppViewModel
     @EnvironmentObject var userInfoManager: UserInfoViewModel
+    @EnvironmentObject var storageManager: StorageManager
     
     // UserDefault를 사용하여 자동 로그인 구현
     @State private var loginCheck = UserDefaults.standard.bool(forKey: "loginCheck")
@@ -18,16 +19,34 @@ struct SettingView: View {
     @State private var isVibrationOn: Bool = true
     @State private var showLogoutAlert: Bool = false
     
+
+    
     var body: some View {
         
         NavigationView {
             VStack(alignment: .leading) {
                 HStack(alignment: .top) {
-                    Image(Constant.ImageName.defaultUserImage)
-                        .resizable()
-                        .clipShape(Circle())
-                        .scaledToFit()
-                        .frame(width: 140, height: 140)
+                    ZStack(alignment: .bottomTrailing) {
+                        Image(uiImage: self.storageManager.profileImage)
+                            .resizable()
+                            .clipShape(Circle())
+                            .scaledToFill()
+                            .frame(width: 140, height: 140)
+
+//                            .onTapGesture {
+//                                isShowingPhotoPicker.toggle()
+//                            }
+//                            .alert(isPresented: $showUpdateProfileImageAlert) {
+//                                Alert(title: Text("프로필 사진 지정"), message: Text("선택한 이미지를 프로필사진으로 지정하시겠습니까?"),
+//                                      primaryButton: .default(Text("예"), action: {
+//                                    //이미지를 파이어 스토리지에 저장한다.
+//                                    print("저장할게요~")
+//                                }),
+//                                      secondaryButton: .destructive(Text("아니오")))
+//                            }
+                    }
+                    .padding(.leading, 5)
+                    
                     VStack(alignment: .leading, spacing: 10) {
                         HStack {
                             Text("\(userInfoManager.userNickName)")
@@ -40,17 +59,19 @@ struct SettingView: View {
                                 // 내 정보 바꾸기 링크
                                 
                             } label: {
-                                Image(systemName: "square.and.pencil")
-                                    .padding(.trailing, 10)
-                                    .padding(.top, 25)
+                                NavigationLink {
+                                    EditProfileView()
+                                } label: {
+                                    Image(systemName: "square.and.pencil")
+                                        .padding(.trailing, 10)
+                                        .padding(.top, 25)
+                                }
                             }
-
                         }
-                        Text("포메를 두마리 키우고 있는 사람입니다! 잘부탁드려요🥰")
+                        Text("\(userInfoManager.userIntroduce)")
                             .foregroundColor(.secondary)
                             .font(.system(size: 14))
                     }
-                    
                     
                 }
                 List {
@@ -107,11 +128,10 @@ struct SettingView: View {
             .background(Color(Constant.CustomColor.lightBrown))
             .navigationTitle(Text("⚙️ 설정"))
             .navigationBarTitleDisplayMode(.inline)
+
         } // NavigationView
         .onAppear {
-            //            if Auth.auth().currentUser != nil {
-            //                userInfoManager.getUserNickName()
-            //            }
+            storageManager.getUserProfileImage(email: userInfoManager.user!.email!)
         }
         
     }


### PR DESCRIPTION
프로필 사진의 이름을 현재사용자의 계정(이메일)로 하여 스토리지에 저장하였고, 메인뷰와 세팅뷰가 출력될때 뷰모델에 있는 함수를 실행토록 하였습니다. 자기소개정보는 이미지와는 다르게 파이어 스토어의 userInfo 컬렉션에 새로운 필드를 만들어 저장 하였습니다.